### PR TITLE
Per 17 add scatterfold etc ops

### DIFF
--- a/app/AST.hs
+++ b/app/AST.hs
@@ -47,11 +47,8 @@ data ExprF a
   = ArithF BinOp a a
   | VarF Name VarDomain
   | FunAppF FuncName [a]
-  | GatherF a a
-  | ScatterAddF a a -- ix targ
   | TransposeF a [Int]
-  | --   | CondF a a a
-    FoldF FuncName a a
+  | FoldF FuncName a a
   | ScanF FuncName a a -- mul e xs
   | LitReal Double
   | LitInt Int

--- a/app/AST.hs
+++ b/app/AST.hs
@@ -11,7 +11,6 @@
 
 module AST where
 
-
 import Control.Comonad.Trans.Cofree (Cofree)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -20,6 +19,7 @@ import Types (Shape, Ty)
 import Util (SrcSpan)
 
 type Name = Text
+
 type FuncName = Text
 
 data BinOp
@@ -79,10 +79,10 @@ data BijectorF a
 
 type Bijector ann = Cofree BijectorF ann
 
-data Decl 
+data Decl
   = CardDecl Name
   | FactorDecl Name
-  | DataDecl Name Ty 
+  | DataDecl Name Ty
   deriving (Show)
 
 -- include shape that is being broadcast over?
@@ -113,9 +113,9 @@ data FunDef ann = FunDef
     _ret :: Ty,
     _body :: (FunBody ann)
   }
-instance Show (FunDef a) where 
-  show (FunDef name args _ _) = show name ++ ' ':show args
 
+instance Show (FunDef a) where
+  show (FunDef name args _ _) = show name ++ ' ' : show args
 
 data DistDef ann = DistDef
   { _distName :: Text,
@@ -127,9 +127,9 @@ data DistDef ann = DistDef
   }
 
 data FunBody ann
-  = LetPrimIn Text Ty (PrimApp ann) (FunBody ann) 
-  | FunLetIn Text Ty (Expr ann) (FunBody ann) 
-  | FunRet (Expr ann) 
+  = LetPrimIn Text Ty (PrimApp ann) (FunBody ann)
+  | FunLetIn Text Ty (Expr ann) (FunBody ann)
+  | FunRet (Expr ann)
 
 data SampleBody ann
   = SampleIn Text Ty (Distribution ann) (SampleBody ann)

--- a/app/AST.hs
+++ b/app/AST.hs
@@ -48,6 +48,11 @@ data ExprF a
   | VarF Name VarDomain
   | FunAppF FuncName [a]
   | GatherF a a
+  | ScatterAddF a a -- ix targ
+  | TransposeF a [Int]
+  | --   | CondF a a a
+    FoldF a a a a Int
+  | ScanF FuncName a a -- mul e xs
   | LitReal Double
   | LitInt Int
   | LitArray [a]

--- a/app/AST.hs
+++ b/app/AST.hs
@@ -51,7 +51,7 @@ data ExprF a
   | ScatterAddF a a -- ix targ
   | TransposeF a [Int]
   | --   | CondF a a a
-    FoldF a a a a Int
+    FoldF FuncName a a
   | ScanF FuncName a a -- mul e xs
   | LitReal Double
   | LitInt Int

--- a/app/Analysis/DistDef.hs
+++ b/app/Analysis/DistDef.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE FlexibleContexts, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Analysis.DistDef where
 
@@ -7,29 +9,28 @@ module Analysis.DistDef where
 import AST
   ( DistDef (DistDef),
     Distribution (Distribution),
+    FunDef (FunDef),
     SampleBody (..),
-    VarDomain (Local, Bound),
-    FunDef (FunDef)
+    VarDomain (Bound, Local),
   )
-import Analysis.Context (MonadTyCtx, insertDist, insertTy, validateType, introCards, introCardsFromTy)
+import Analysis.Context (Ctx, MonadTyCtx, insertDist, insertTy, introArgs, introCards, introCardsFromTy, validateType)
 import Analysis.Distribution (inferTyDist)
 import Analysis.Error
 import Analysis.Expr (inferTy)
-import Analysis.FunDef (checkFunDefs, checkFunDef)
+import Analysis.FunDef (checkFunDef, checkFunDefs)
 import Control.Comonad.Identity (Identity (runIdentity))
 import Control.Comonad.Trans.Cofree (Cofree, headF)
 import Control.Monad (when)
+import Control.Monad.Reader (MonadReader (ask), runReaderT)
+import Control.Monad.Reader.Class (MonadReader (local))
+import Control.Monad.State.Strict (MonadState (get))
+import Control.Monad.Validate (MonadValidate)
 import Data.Functor.Compose (Compose (getCompose))
 import Data.Functor.Foldable (Recursive (project))
-import qualified Data.Set as S 
+import qualified Data.Set as S
 import qualified Data.Vector as V
-import Types (FunctionTy (FunctionTy), Ty, shape, broadcastsTo, Shape (getVec))
-import Control.Monad.Reader.Class (MonadReader(local))
-import Control.Monad.State.Strict (MonadState (get))
-import Analysis.Context (Ctx)
-import Control.Monad.Reader (runReaderT, MonadReader (ask))
+import Types (FunctionTy (FunctionTy), Shape (getVec), Ty, broadcastsTo, shape)
 import Util (SrcSpan)
-import Control.Monad.Validate (MonadValidate)
 
 cofreeHead :: Functor f => Cofree f a -> a
 cofreeHead = headF . runIdentity . getCompose . project
@@ -40,20 +41,20 @@ checkDistDefs dists = traverse go dists
     go :: DistDef SrcSpan -> m (DistDef Ty)
     go dist = do
       ctx <- get
-      dist'@(DistDef name args eventTy lpdf sample bij) <- 
+      dist'@(DistDef name args eventTy lpdf sample bij) <-
         runReaderT (checkDistDef dist) ctx
       insertDist name (FunctionTy args eventTy) (const () <$> bij)
       return dist'
 
 checkDistDef ::
+  forall m.
   (MonadTyCtx m) =>
   DistDef SrcSpan ->
   m (DistDef Ty)
 checkDistDef (DistDef name args eventTy lpdf sample bij) = do
-  ctx <- ask   
+  ctx <- ask
   lpdf' <- checkFunDef lpdf
-  let insertArgs = mconcat [insertTy x Bound t . introCardsFromTy t | (x, t) <- args]
-  (eventTy', sample') <- local insertArgs $ checkSample sample
+  (eventTy', sample') <- local (introArgs args) $ checkSample sample
   -- let err = expectedGot eventTy eventTy'
   when (eventTy' /= eventTy) $ doesNotMatchReturnType eventTy eventTy'
   let bij' = (const eventTy) <$> bij
@@ -75,11 +76,11 @@ checkSample (SampleUnifIn name ty rest) = local (insertTy name Local ty) $ do
   validateType ty
   (eventTy, rest') <- checkSample rest
   return (eventTy, SampleUnifIn name ty rest')
-checkSample (SampleLetIn name ty val rest) = local (insertTy name Local ty) $ do
+checkSample (SampleLetIn name ty val rest) = do
   validateType ty
   val' <- inferTy val
   let ty' = cofreeHead val'
   -- let err = expectedGot ty ty'
   when (not $ ty' `broadcastsTo` ty) $ doesNotMatchDeclaredType ty ty'
-  (eventTy, rest') <- checkSample rest
+  (eventTy, rest') <- local (insertTy name Local ty) $ checkSample rest
   return (eventTy, SampleLetIn name ty val' rest')

--- a/app/Analysis/Error.hs
+++ b/app/Analysis/Error.hs
@@ -7,8 +7,8 @@
 module Analysis.Error where
 
 import AST (BinOp)
-import Control.Monad.Except ( MonadError(throwError) )
-import Control.Monad.Validate (MonadValidate(..), refute, dispute)
+import Control.Monad.Except (MonadError (throwError))
+import Control.Monad.Validate (MonadValidate (..), dispute, refute)
 import Data.Foldable (toList)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -41,7 +41,7 @@ import Util (SrcSpan)
 type TypeError = Diagnostic T.Text
 
 mkDiagnostic :: Report msg -> Diagnostic msg
-mkDiagnostic = addReport def 
+mkDiagnostic = addReport def
 
 badFunApp ::
   MonadValidate TypeError m =>
@@ -51,7 +51,7 @@ badFunApp ::
   FunctionTy ->
   m a
 badFunApp fname fnAppPos given fty@(FunctionTy argTys _) =
-  refute . mkDiagnostic $ 
+  refute . mkDiagnostic $
     Err
       Nothing
       ("Error in application of function " <> fname)
@@ -249,6 +249,90 @@ invalidGather loc t1 t2 =
       "Invalid gather"
       [(loc, Blank)]
       []
+
+invalidFold ::
+  MonadValidate TypeError m =>
+  SrcSpan ->
+  FunctionTy ->
+  Ty ->
+  Ty ->
+  m a
+invalidFold loc fty x0@(Ty _ _ (Just x0l)) xs@(Ty _ _ (Just xsl)) =
+  refute . mkDiagnostic $
+    Err
+      Nothing
+      "Invalid fold"
+      [ (x0l, Where $ "has type " <> (T.pack $ show x0)),
+        (xsl, Where $ "has type " <> (T.pack $ show xs)),
+        ( let Position (l, c) _ f = loc in Position (l, c) (l, c + 4) f,
+          This . T.intercalate "\n" $
+            [ "fold expects to be called as fold(f, init, xs) where",
+              "  f    : (b : ['m..]real, a : ['n..]real) -> ['m..]real",
+              "  init : ['m..]real",
+              "  xs   : ['p.., 'n..]real"
+            ]
+        )
+      ]
+      []
+invalidFold loc fty x0 xs =
+  refute . mkDiagnostic $
+    Err
+      Nothing
+      "Invalid fold"
+      [ ( let Position (l, c) _ f = loc in Position (l, c) (l, c + 4) f,
+          This . T.intercalate "\n" $
+            [ "fold expects to be called as fold(f, init, xs) where",
+              "  f    : (b : ['m..]real, a : ['n..]real) -> ['m..]real",
+              "  init : ['m..]real",
+              "  xs   : ['p.., 'n..]real"
+            ]
+        )
+      ]
+      [ Note $ "has type " <> (T.pack $ show x0),
+        Note $ "has type " <> (T.pack $ show xs)
+      ]
+
+invalidScan ::
+  MonadValidate TypeError m =>
+  SrcSpan ->
+  FunctionTy ->
+  Ty ->
+  Ty ->
+  m a
+invalidScan loc fty x0@(Ty _ _ (Just x0l)) xs@(Ty _ _ (Just xsl)) =
+  refute . mkDiagnostic $
+    Err
+      Nothing
+      "Invalid scan"
+      [ (x0l, Where $ "has type " <> (T.pack $ show x0)),
+        (xsl, Where $ "has type " <> (T.pack $ show xs)),
+        ( let Position (l, c) _ f = loc in Position (l, c) (l, c + 4) f,
+          This . T.intercalate "\n" $
+            [ "scan expects to be called as scan(f, init, xs) where",
+              "  f    : (b : ['m..]real, a : ['n..]real) -> ['m..]real",
+              "  init : ['m..]real",
+              "  xs   : ['p.., 'n..]real"
+            ]
+        )
+      ]
+      []
+invalidScan loc fty x0 xs =
+  refute . mkDiagnostic $
+    Err
+      Nothing
+      "Invalid scan"
+      [ ( let Position (l, c) _ f = loc in Position (l, c) (l, c + 4) f,
+          This . T.intercalate "\n" $
+            [ "scan expects to be called as scan(f, init, xs) where",
+              "  f    : (b : ['m..]real, a : ['n..]real) -> ['m..]real",
+              "  init : ['m..]real",
+              "  xs   : ['p.., 'n..]real"
+            ]
+        )
+      ]
+      [ Note $ "has type " <> (T.pack $ show x0),
+        Note $ "has type " <> (T.pack $ show xs)
+      ]
 
 nonHomogenousArrayLit :: (MonadValidate TypeError m) => a -> m b
 nonHomogenousArrayLit _tys =

--- a/app/Analysis/Error.hs
+++ b/app/Analysis/Error.hs
@@ -236,20 +236,6 @@ binOpErr op pos t1 t2 =
         Note $ "The right hand side has type " <> (T.pack $ show t2)
       ]
 
-invalidGather ::
-  MonadValidate TypeError m =>
-  SrcSpan ->
-  Ty ->
-  Ty ->
-  m a
-invalidGather loc t1 t2 =
-  refute . mkDiagnostic $
-    Err
-      Nothing
-      "Invalid gather"
-      [(loc, Blank)]
-      []
-
 invalidFold ::
   MonadValidate TypeError m =>
   SrcSpan ->

--- a/app/Analysis/Expr.hs
+++ b/app/Analysis/Expr.hs
@@ -12,7 +12,14 @@ import Analysis.Context
     lookupFun,
     lookupVar,
   )
-import Analysis.Error -- (TypeError (..), blame)
+import Analysis.Error
+  ( badFunApp,
+    binOpErr,
+    invalidFold,
+    invalidScan,
+    nonHomogenousArrayLit,
+    otherErr,
+  )
 import Control.Comonad.Identity (Identity (Identity, runIdentity))
 import Control.Comonad.Trans.Cofree (Cofree, CofreeF (..))
 import Control.Monad (when)

--- a/app/Analysis/Expr.hs
+++ b/app/Analysis/Expr.hs
@@ -35,7 +35,7 @@ import Util (SrcSpan, joinSrcSpan)
 
 inferTy ::
   forall m.
-  ( MonadTyCtx m ) =>
+  (MonadTyCtx m) =>
   Cofree ExprF SrcSpan ->
   m (Cofree ExprF Ty)
 inferTy = para (go . runIdentity . getCompose)
@@ -79,7 +79,7 @@ alg loc (FunAppF fname arg_tys) = do
   case unify arg_tys' fty of
     Left _ -> badFunApp fname loc arg_tys' fty
     Right (_, ret) -> return ret
-alg loc (LitReal _) = return $ Ty [] REAL (Just loc) 
+alg loc (LitReal _) = return $ Ty [] REAL (Just loc)
 alg loc (LitInt _) = return $ Ty [] INT (Just loc)
 alg loc (LitArray []) = otherErr "Cannot infer type of empty tensor"
 alg loc (LitArray tys) = do
@@ -88,4 +88,4 @@ alg loc (LitArray tys) = do
     then
       let (Ty sh el _) = head tys'
        in return $ Ty (shCons (CardN $ length tys') sh) el (Just loc)
-    else nonHomogenousArrayLit tys' 
+    else nonHomogenousArrayLit tys'

--- a/app/CodeGen/Expr.hs
+++ b/app/CodeGen/Expr.hs
@@ -14,40 +14,69 @@ import AST
 import CodeGen.Python
   ( PyExp (..),
     jnp,
+    lax,
+    (!),
+    (!$),
     (@@),
   )
-import Control.Comonad.Trans.Cofree (tailF)
+import Control.Comonad.Trans.Cofree (CofreeF ((:<)), tailF)
 import Data.Functor.Compose (Compose (..))
 import Data.Functor.Foldable (Recursive (cata))
 import Data.Functor.Identity (Identity (..))
 import qualified Data.Text as T
+import Types (Card (..), Shape, Ty (..), shToList, shape)
 
-cgExpr :: Expr w -> PyExp
-cgExpr = cata (go . proj)
+cgExpr :: Expr Ty -> PyExp
+cgExpr = cata (\(Compose (Identity (ty :< e))) -> go ty e)
   where
     proj = tailF . runIdentity . getCompose
-    go :: ExprF PyExp -> PyExp
-    go (ArithF op x y) = case op of
+    go :: Ty -> ExprF PyExp -> PyExp
+    go _ (ArithF op x y) = case op of
       Add -> jnp "add" @@ [x, y]
       Mul -> jnp "multiply" @@ [x, y]
       Sub -> jnp "subtract" @@ [x, y]
       Div -> jnp "divide" @@ [x, y]
-    go (LitInt n) = PyNum (Right n)
-    go (LitReal x) = PyNum (Left x)
-    go (LitArray xs) = PyList xs
-    go (VarF name Unknown) = PyIdent [] (name <> "_ack")
-    go (VarF name Local) = PyIdent [] ("_local_" <> name)
-    go (VarF name Bound) = PyIdent [] ("_bd_" <> name)
-    go (VarF name Val) = PyIdent [] (name <> "_val")
-    go (VarF name Data) = PyGet (PyIdent [] "data") (PyStr name)
-    go (VarF name Param) = PyIdent [] (name <> "_tr")
-    go (FunAppF "mean" xs) =
+    go _ (LitInt n) = PyNum (Right n)
+    go _ (LitReal x) = PyNum (Left x)
+    go _ (LitArray xs) = PyList xs
+    go _ (VarF name Unknown) = PyIdent [] (name <> "_ack")
+    go _ (VarF name Local) = PyIdent [] ("_local_" <> name)
+    go _ (VarF name Bound) = PyIdent [] ("_bd_" <> name)
+    go _ (VarF name Val) = PyIdent [] (name <> "_val")
+    go _ (VarF name Data) = PyGet (PyIdent [] "data") (PyStr name)
+    go _ (VarF name Param) = PyIdent [] (name <> "_tr")
+    go _ (FunAppF "mean" xs) =
       PyApply
         "jnp.mean"
         xs
         [("axis", PyNum $ Right (-1))]
-    go (FunAppF f xs) = jnp f @@ xs
-    go (GatherF xs is) = PyGet xs is -- jnp "gather" @@ [xs, is]
+    go _ (FunAppF f xs) = jnp f @@ xs
+    go _ (GatherF xs is) = PyGet xs is -- jnp "gather" @@ [xs, is]
+    go t (ScatterAddF xs is) =
+      let z = jnp "zeros" @@ [cgShape . shape $ t]
+       in ((z !$ "at") [is]) !$ "add" $ [xs]
+    go _ (FoldF f x0 xs) = lax "reduce" @@ [xs, x0, PyIdent [] f]
+    go _ (ScanF f x0 xs) =
+      lax "scan"
+        @@ [ PyLambda ["c", "a"] $
+               PyTuple
+                 [ (PyIdent [] f) @@ [PyIdent [] "c", PyIdent [] "a"],
+                   PyIdent [] "c"
+                 ],
+             x0,
+             xs
+           ]
+    go _ (TransposeF x perm) =
+      lax "transpose"
+        @@ [x, PyList (PyNum . Right <$> perm)]
+
+cgShape :: Shape -> PyExp
+cgShape sh = PyList $ cgCard <$> (shToList $ sh)
+
+cgCard :: Card -> PyExp
+cgCard (CardFV n) = "cards" ! PyStr n
+cgCard (CardN n) = PyNum $ Right n
+cgCard (CardBV n) = "cards_local" ! PyStr n
 
 cgFun (FunAppF "mean" xs) = PyApply "jnp.mean" xs [("axis", PyNum $ Right (-1))]
 cgFun (FunAppF f xs) = case f of

--- a/app/CodeGen/Expr.hs
+++ b/app/CodeGen/Expr.hs
@@ -51,10 +51,6 @@ cgExpr = cata (\(Compose (Identity (ty :< e))) -> go ty e)
         xs
         [("axis", PyNum $ Right (-1))]
     go _ (FunAppF f xs) = jnp f @@ xs
-    go _ (GatherF xs is) = PyGet xs is -- jnp "gather" @@ [xs, is]
-    go t (ScatterAddF xs is) =
-      let z = jnp "zeros" @@ [cgShape . shape $ t]
-       in ((z !$ "at") [is]) !$ "add" $ [xs]
     go _ (FoldF f x0 xs) = lax "reduce" @@ [xs, x0, PyIdent [] f]
     go _ (ScanF f x0 xs) =
       lax "scan"

--- a/app/CodeGen/FunDef.hs
+++ b/app/CodeGen/FunDef.hs
@@ -7,22 +7,23 @@ import CodeGen.Python
     PyExp (PyIdent),
     (@@),
   )
+import Types (Ty)
 
-cgFunDef :: FunDef a -> PyCode
+cgFunDef :: FunDef Ty -> PyCode
 cgFunDef (FunDef name args ret body) = PyDef Nothing name' argNames body'
   where
     argNames = ("_bd_" <>) . fst <$> args
     name' = "_func_" <> name
     body' = cgFunBody body
 
-cgFunBody :: FunBody a -> PyCode
+cgFunBody :: FunBody Ty -> PyCode
 cgFunBody (FunRet val) = PyRet $ cgExpr val
 cgFunBody (LetPrimIn x _ pApp rest) =
   PyBlock [PyAssign ("_local_" <> x) (cgPrimApp pApp), cgFunBody rest]
 cgFunBody (FunLetIn x _ val rest) =
   PyBlock [PyAssign ("_local_" <> x) (cgExpr val), cgFunBody rest]
 
-cgPrimApp :: PrimApp a -> PyExp
+cgPrimApp :: PrimApp Ty -> PyExp
 cgPrimApp (PrimApp name args) = (PyIdent mod f) @@ (cgExpr <$> args)
   where
     mod = init name

--- a/app/Parser/Expr.hs
+++ b/app/Parser/Expr.hs
@@ -144,14 +144,4 @@ pApp = do
   funcName <- pIdent
   args <- parens $ pExpr `sepBy` symbol ","
   to <- getSourcePos
-  case funcName of
-    "gather" -> case args of
-      [xs, is] -> return . cofree $ (mkPos from to) :< GatherF xs is
-      _ -> fail "gather expects 2 arguments"
-    "scatter_add" -> case args of
-      [xs, is] -> return . cofree $ (mkPos from to) :< ScatterAddF xs is
-      _ -> fail "scatter_add expects 2 arguments"
-    "fold" -> fail "bad fold"
-    "scan" -> fail "bad scan"
-    "transpose" -> fail "bad transpose"
-    _ -> return . cofree $ (mkPos from to) :< FunAppF funcName args
+  return . cofree $ (mkPos from to) :< FunAppF funcName args

--- a/app/Parser/Expr.hs
+++ b/app/Parser/Expr.hs
@@ -65,6 +65,9 @@ pTerm :: Parser ExprSrc
 pTerm =
   choice
     [ parens pExpr,
+      try pFold,
+      try pScan,
+      try pTranspose,
       try pApp,
       try pVariable,
       pLit
@@ -148,4 +151,7 @@ pApp = do
     "scatter_add" -> case args of
       [xs, is] -> return . cofree $ (mkPos from to) :< ScatterAddF xs is
       _ -> fail "scatter_add expects 2 arguments"
+    "fold" -> fail "bad fold"
+    "scan" -> fail "bad scan"
+    "transpose" -> fail "bad transpose"
     _ -> return . cofree $ (mkPos from to) :< FunAppF funcName args

--- a/app/Parser/Expr.hs
+++ b/app/Parser/Expr.hs
@@ -13,6 +13,7 @@ import Control.Monad.Combinators.Expr
   )
 import Parser.Util
   ( Parser,
+    integer,
     lexeme,
     pIdent,
     parens,
@@ -29,27 +30,27 @@ import Text.Megaparsec
   )
 import Util (mkPos)
 
-withLoc parser = do 
-  from <- getSourcePos 
-  x <- parser 
-  to <- getSourcePos 
-  return . cofree $ (mkPos from to) :< x  
-
+withLoc parser = do
+  from <- getSourcePos
+  x <- parser
+  to <- getSourcePos
+  return . cofree $ (mkPos from to) :< x
 
 pVariable :: Parser ExprSrc
 pVariable = withLoc $ VarF <$> (lexeme pIdent) <*> (pure Unknown)
 
-
 pLitInt :: Parser ExprSrc
 pLitInt = withLoc $ LitInt . fromInteger <$> signedInteger
-
 
 pLitReal :: Parser ExprSrc
 pLitReal = withLoc $ LitReal <$> signedFloat
 
 pLitArray :: Parser ExprSrc
-pLitArray = withLoc $ 
-  between (symbol "[") (symbol "]")
+pLitArray =
+  withLoc $
+    between
+      (symbol "[")
+      (symbol "]")
       (LitArray <$> sepBy pExpr (symbol ","))
 
 pLit :: Parser (ExprSrc)
@@ -59,7 +60,6 @@ pLit =
       try pLitReal,
       pLitInt
     ]
-
 
 pTerm :: Parser ExprSrc
 pTerm =
@@ -97,7 +97,6 @@ pSub = do
   loc' <- getSourcePos
   return $ \x y -> cofree $ (mkPos loc loc') :< ArithF Sub x y
 
-
 operatorTable :: [[Operator Parser ExprSrc]]
 operatorTable =
   [ [ InfixL pMul,
@@ -108,14 +107,45 @@ operatorTable =
     ]
   ]
 
+pFold = do
+  let comma = symbol ","
+  from <- getSourcePos
+  "fold"
+  fold <- parens $ FoldF <$> (pIdent <* comma) <*> (pExpr <* comma) <*> pExpr
+  to <- getSourcePos
+  return . cofree $ (mkPos from to) :< fold
+
+pScan = do
+  let comma = symbol ","
+  from <- getSourcePos
+  "scan"
+  scan <- parens $ ScanF <$> (pIdent <* comma) <*> (pExpr <* comma) <*> pExpr
+  to <- getSourcePos
+  return . cofree $ (mkPos from to) :< scan
+
+pTranspose = do
+  from <- getSourcePos
+  "transpose"
+  tr <- parens $ TransposeF <$> (pExpr <* comma) <*> pPerm
+  to <- getSourcePos
+  return . cofree $ (mkPos from to) :< tr
+  where
+    comma = symbol ","
+    pPerm =
+      between (symbol "[") (symbol "]") $
+        sepBy (fmap fromIntegral integer) comma
+
 pApp :: Parser ExprSrc
 pApp = do
   from <- getSourcePos
   funcName <- pIdent
   args <- parens $ pExpr `sepBy` symbol ","
-  to <- getSourcePos  
+  to <- getSourcePos
   case funcName of
     "gather" -> case args of
       [xs, is] -> return . cofree $ (mkPos from to) :< GatherF xs is
       _ -> fail "gather expects 2 arguments"
+    "scatter_add" -> case args of
+      [xs, is] -> return . cofree $ (mkPos from to) :< ScatterAddF xs is
+      _ -> fail "scatter_add expects 2 arguments"
     _ -> return . cofree $ (mkPos from to) :< FunAppF funcName args


### PR DESCRIPTION
Implementation of fold and scan. 
Removed Gather/Scatter from AST primitives, instead implement them as functions in the standard library. 